### PR TITLE
安装项目后无法调用BioName

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
         long_description=long_description,
         long_description_content_type="text/markdown",
         package_data = {
-            '':['lib/*.py', 'lib/*.json', 'label/*.py', 'label/*.mustache', 'label/*.css', 'occurrence/*.py', 'table/*.py']
+            '':['function/*.py','lib/*.py', 'lib/*.json', 'label/*.py', 'label/*.mustache', 'label/*.css', 'occurrence/*.py', 'table/*.py']
             },
         platforms = 'any',
         python_requires=">=3.6.1, <3.10",


### PR DESCRIPTION
操作：在命令行中运行python setup.py install后，运行 from ipybd import BioName
报错显示：” ModuleNotFoundError: No module named 'ipybd.function' “
原因：项目中setup.py中package_data不包括function文件夹
解决方案：在package_data中加入function/*.py将此文件夹中的文件引用